### PR TITLE
Feature/handle message exception

### DIFF
--- a/Miki.Framework/Extension/DiscordExtensions.cs
+++ b/Miki.Framework/Extension/DiscordExtensions.cs
@@ -62,7 +62,7 @@ namespace Miki.Discord
 
 		public static IMessageReference ThenWait(this IMessageReference reference, int milliseconds)
 		{
-			reference.OnSuccess(async (msg) =>
+			reference.ProcessAfterComplete(async (msg) =>
 			{
 				await Task.Delay(milliseconds);
 			});
@@ -71,7 +71,7 @@ namespace Miki.Discord
 
 		public static IMessageReference ThenDelete(this IMessageReference reference)
 		{
-			reference.OnSuccess(async (msg) =>
+			reference.ProcessAfterComplete(async (msg) =>
 			{
 				await msg.DeleteAsync();
 			});
@@ -80,7 +80,7 @@ namespace Miki.Discord
 
 		public static IMessageReference ThenEdit(this IMessageReference reference, string message = "", DiscordEmbed embed = null)
 		{
-			reference.OnSuccess(async (x) => await x.EditAsync(new EditMessageArgs
+			reference.ProcessAfterComplete(async (x) => await x.EditAsync(new EditMessageArgs
 			{
 				content = message,
 				embed = embed
@@ -90,7 +90,7 @@ namespace Miki.Discord
 
         public static IMessageReference Catch(this IMessageReference reference, Func<MessageExceptionArguments, Task> fn)
         {
-            reference.OnException(fn);
+            reference.ProcessOnException(fn);
             return reference;
         }
 
@@ -111,7 +111,7 @@ namespace Miki.Discord
 
         public static IMessageReference Then(this IMessageReference reference, Func<IDiscordMessage, Task> fn)
 		{
-			reference.OnSuccess(fn);
+			reference.ProcessAfterComplete(fn);
 			return reference;
 		}
 

--- a/Miki.Framework/MessageBucket.cs
+++ b/Miki.Framework/MessageBucket.cs
@@ -12,9 +12,9 @@ namespace Miki.Framework
 {
 	public interface IMessageReference
 	{
-        void OnSuccess(Func<IDiscordMessage, Task> fn);
+        void ProcessAfterComplete(Func<IDiscordMessage, Task> fn);
 
-        void OnException(Func<MessageExceptionArguments, Task> fn);
+        void ProcessOnException(Func<MessageExceptionArguments, Task> fn);
     }
 
 	public class MessageBucketArgs
@@ -31,12 +31,12 @@ namespace Miki.Framework
 
         public MessageBucketArgs Arguments;
 
-		public void OnSuccess(Func<IDiscordMessage, Task> fn)
+		public void ProcessAfterComplete(Func<IDiscordMessage, Task> fn)
 		{
 			SuccessActions.Add(fn);
         }
 
-        public void OnException(Func<MessageExceptionArguments, Task> fn)
+        public void ProcessOnException(Func<MessageExceptionArguments, Task> fn)
         {
             ExceptionActions.Add(fn);
         }


### PR DESCRIPTION
This PR adds the method `OnException` (with the extension method `Catch`) on the IMessageReference interface. This can be used when a message cannot be sent in the current channel (for example the DMs of a user).

**Example**
```csharp
await embedBuilder.ToEmbed()
    .QueueAsync(await e.GetAuthor().GetDMChannelAsync(), "Join our support server: https://discord.gg/39Xpj7K")
    .Then(msg =>
    {
        var embed = new EmbedBuilder
            {
                Description = e.GetLocale().GetString("miki_module_general_help_dm"),
                Color = new Color(0.6f, 0.6f, 1.0f)
            }
            .ToEmbed();

        return embed.QueueAsync(e.GetChannel());
    })
    .Catch(args =>
    {
        // The bot doesn't have access to the DMs because the author didn't add 2FA or the user blocks DMs.
        // Send it in the channel instead.

        args.LogException = false;

        return args.Reference.RequeueAsync(e.GetChannel());
    });
```