### PR TITLE
Added Microsoft.Extensions.Hosting support

### DIFF
--- a/src/Miki.Framework.Commands/CommandPipeline.cs
+++ b/src/Miki.Framework.Commands/CommandPipeline.cs
@@ -1,4 +1,6 @@
-﻿namespace Miki.Framework.Commands
+﻿using Miki.Framework.Models;
+
+namespace Miki.Framework.Commands
 {
     using System;
     using System.Collections.Generic;
@@ -28,7 +30,7 @@
         public async ValueTask ExecuteAsync(IDiscordMessage data)
         {
             var sw = Stopwatch.StartNew();
-            using ContextObject contextObj = new ContextObject(services, data);
+            using ContextObject contextObj = new ContextObject(services, new DiscordMessage(data));
             int index = 0;
 
             Func<ValueTask> nextFunc = null;

--- a/src/Miki.Framework.Commands/CommandPipeline.cs
+++ b/src/Miki.Framework.Commands/CommandPipeline.cs
@@ -1,12 +1,11 @@
-﻿using Miki.Framework.Models;
-
-namespace Miki.Framework.Commands
+﻿namespace Miki.Framework.Commands
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Threading.Tasks;
     using Miki.Discord.Common;
+    using Miki.Framework.Models;
     using Miki.Framework.Commands.Pipelines;
     using Miki.Logging;
 

--- a/src/Miki.Framework.Commands/CommandPipeline.cs
+++ b/src/Miki.Framework.Commands/CommandPipeline.cs
@@ -28,7 +28,7 @@
         public async ValueTask ExecuteAsync(IDiscordMessage data)
         {
             var sw = Stopwatch.StartNew();
-            using ContextObject contextObj = new ContextObject(services);
+            using ContextObject contextObj = new ContextObject(services, data);
             int index = 0;
 
             Func<ValueTask> nextFunc = null;

--- a/src/Miki.Framework.Commands/CommandPipelineBuilder.cs
+++ b/src/Miki.Framework.Commands/CommandPipelineBuilder.cs
@@ -44,5 +44,14 @@
 			stages.Add(stage);
 			return this;
 		}
+
+		/// <summary>
+		/// Initializes a pipeline stage as a runnable stage in the pipeline.
+		/// </summary>
+		public CommandPipelineBuilder UseStage<T>()
+			where T : class, IPipelineStage
+		{
+			return UseStage(Services.GetOrCreateService<T>());
+		}
 	}
 }

--- a/src/Miki.Framework.Commands/CommandPipelineBuilder.cs
+++ b/src/Miki.Framework.Commands/CommandPipelineBuilder.cs
@@ -9,12 +9,14 @@
 	/// </summary>
     public class CommandPipelineBuilder
 	{
+		private readonly List<IPipelineStage> stages = new List<IPipelineStage>();
+
 		/// <summary>
 		/// Services that can be used throughout the command pipeline.
 		/// </summary>
         public IServiceProvider Services { get; }
 
-        private readonly List<IPipelineStage> stages = new List<IPipelineStage>();
+        public IReadOnlyList<IPipelineStage> Stages => stages;
 
 		/// <summary>
 		/// Creates a new CommandPipelineBuilder. 

--- a/src/Miki.Framework.Commands/CommandTreeBuilder.cs
+++ b/src/Miki.Framework.Commands/CommandTreeBuilder.cs
@@ -1,136 +1,52 @@
-﻿namespace Miki.Framework.Commands
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Miki.Framework.Commands
 {
-    using Miki.Framework.Commands.Nodes;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using System.Threading.Tasks;
-    
     public class CommandTreeBuilder
 	{
-        [Obsolete("use 'CommandTreeBuilder::AddCommandBuildStep()' intead")]
-		public event Action<NodeContainer, IServiceProvider> OnContainerLoaded;
+		private readonly List<Type> types = new List<Type>();
 
-		private readonly IServiceProvider services;
-
-        private List<ICommandBuildStep> buildSteps;
-
-		public CommandTreeBuilder(IServiceProvider services)
+		public CommandTreeBuilder(IServiceCollection services)
 		{
-			this.services = services;
+			Services = services;
         }
-
-        public CommandTreeBuilder AddCommandBuildStep(ICommandBuildStep buildStep)
+		
+		public IServiceCollection Services { get; }
+		
+		public CommandTreeBuilder AddType(Type type)
+		{
+			types.Add(type);
+			return this;
+		}
+		
+        public CommandTreeBuilder AddAssembly(Assembly assembly)
         {
-            if(buildSteps == null)
-            {
-                buildSteps = new List<ICommandBuildStep>();
-            }
-            buildSteps.Add(buildStep);
-            return this;
+	        types.AddRange(assembly.GetTypes().Where(x => x.GetCustomAttribute<ModuleAttribute>() != null));
+	        return this;
+        }
+        
+        public CommandTree Build(IServiceProvider provider)
+        {
+	        var root = new CommandTree();
+	        var compiler = ActivatorUtilities.CreateInstance<CommandTreeCompiler>(provider);
+
+	        foreach (var type in types)
+	        {
+		        var module = compiler.LoadModule(type, root.Root);
+		        
+		        if (module != null)
+		        {
+			        root.Root.Children.Add(module);
+		        }
+	        }
+			
+	        return root;
         }
 
-		public CommandTree Create(Assembly assembly)
-		{
-			var allTypes = assembly.GetTypes()
-				.Where(x => x.GetCustomAttribute<ModuleAttribute>() != null);
-			var root = new CommandTree();
-			foreach(var t in allTypes)
-			{
-				var module = LoadModule(t, root.Root);
-				if(module != null)
-				{
-					root.Root.Children.Add(module);
-				}
-			}
-			return root;
-		}
-
-		private NodeContainer LoadModule(Type t, NodeContainer parent)
-		{
-			var moduleAttrib = t.GetCustomAttribute<ModuleAttribute>();
-			if(moduleAttrib == null)
-			{
-				throw new InvalidOperationException("Modules must have a valid ModuleAttribute.");
-			}
-
-			NodeContainer module = new NodeModule(moduleAttrib.Name, parent, services, t);
-			OnContainerLoaded?.Invoke(module, services);
-
-			var allCommands = t.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public)
-				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
-			foreach(var c in allCommands)
-			{
-				module.Children.Add(LoadCommand(c, module));
-			}
-
-			var allSingleCommands = t.GetMethods()
-				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
-			foreach(var c in allSingleCommands)
-			{
-				module.Children.Add(LoadCommand(c, module));
-			}
-
-			return module;
-		}
-		private Node LoadCommand(Type t, NodeContainer parent)
-		{
-			var commandAttrib = t.GetCustomAttribute<CommandAttribute>();
-			if(commandAttrib == null)
-			{
-				throw new InvalidOperationException(
-					$"Multi command of type '{t.ToString()}' must have a valid CommandAttribute.");
-			}
-
-			if(commandAttrib.Aliases?.Count() == 0)
-			{
-				throw new InvalidOperationException(
-					$"Multi commands cannot have an invalid name.");
-			}
-
-			var multiCommand = new NodeNestedExecutable(commandAttrib.AsMetadata(), parent, services, t);
-			OnContainerLoaded?.Invoke(multiCommand, services);
-
-			var allCommands = t.GetNestedTypes()
-				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
-			foreach(var c in allCommands)
-			{
-				multiCommand.Children.Add(LoadCommand(c, multiCommand));
-			}
-
-			var allSingleCommands = t.GetMethods()
-				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
-			foreach(var c in allSingleCommands)
-			{
-				var attrib = c.GetCustomAttribute<CommandAttribute>();
-				if(attrib.Aliases == null
-					|| attrib.Aliases.Count() == 0)
-				{
-					var node = LoadCommand(c, multiCommand);
-					if(node is IExecutable execNode)
-					{
-						multiCommand.SetDefaultExecution(async (e)
-							=> await execNode.ExecuteAsync(e));
-					}
-				}
-				else
-				{
-					multiCommand.Children.Add(LoadCommand(c, multiCommand));
-				}
-			}
-			return multiCommand;
-		}
-		private Node LoadCommand(MethodInfo m, NodeContainer parent)
-		{
-			var commandAttrib = m.GetCustomAttribute<CommandAttribute>();
-			var command = new NodeExecutable(commandAttrib.AsMetadata(), parent, m);
-
-			if(m.ReturnType != typeof(Task))
-			{
-				throw new Exception("Methods with attribute 'Command' require to be Tasks.");
-			}
-			return command;
-		}
 	}
 }

--- a/src/Miki.Framework.Commands/CommandTreeCompiler.cs
+++ b/src/Miki.Framework.Commands/CommandTreeCompiler.cs
@@ -1,0 +1,179 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading.Tasks;
+using Miki.Framework.Commands.Nodes;
+using Miki.Framework.Hosting;
+using Miki.Framework.Models;
+
+namespace Miki.Framework.Commands
+{
+    internal class CommandTreeCompiler
+    {
+	    private static readonly PropertyInfo TaskCompleteProperty = typeof(Task).GetProperty(nameof(Task.CompletedTask));
+
+	    private readonly IReadOnlyList<IParameterProvider> parameterProviders;
+
+	    public CommandTreeCompiler(IEnumerable<IParameterProvider> parameterProviders)
+	    {
+		    this.parameterProviders = parameterProviders.ToArray();
+	    }
+
+	    public NodeContainer LoadModule(Type t, NodeContainer parent)
+		{
+			var moduleAttrib = t.GetCustomAttribute<ModuleAttribute>();
+			if(moduleAttrib == null)
+			{
+				throw new InvalidOperationException("Modules must have a valid ModuleAttribute.");
+			}
+
+			NodeContainer module = new NodeModule(moduleAttrib.Name, parent, t);
+
+			var allCommands = t.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public)
+				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
+			foreach(var c in allCommands)
+			{
+				module.Children.Add(LoadCommand(c, module));
+			}
+
+			var allSingleCommands = t.GetMethods()
+				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
+			foreach(var c in allSingleCommands)
+			{
+				module.Children.Add(LoadCommand(c, module));
+			}
+
+			return module;
+		}
+	    
+		private Node LoadCommand(Type t, NodeContainer parent)
+		{
+			var commandAttrib = t.GetCustomAttribute<CommandAttribute>();
+			if(commandAttrib == null)
+			{
+				throw new InvalidOperationException(
+					$"Multi command of type '{t}' must have a valid CommandAttribute.");
+			}
+
+			if(commandAttrib.Aliases?.Count == 0)
+			{
+				throw new InvalidOperationException(
+					$"Multi commands cannot have an invalid name.");
+			}
+
+			var multiCommand = new NodeNestedExecutable(commandAttrib.AsMetadata(), parent, t);
+
+			var allCommands = t.GetNestedTypes()
+				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
+			foreach(var c in allCommands)
+			{
+				multiCommand.Children.Add(LoadCommand(c, multiCommand));
+			}
+
+			var allSingleCommands = t.GetMethods()
+				.Where(x => x.GetCustomAttribute<CommandAttribute>() != null);
+			foreach(var c in allSingleCommands)
+			{
+				var attrib = c.GetCustomAttribute<CommandAttribute>();
+				if(attrib.Aliases == null
+					|| attrib.Aliases.Count() == 0)
+				{
+					var node = LoadCommand(c, multiCommand);
+					if(node is IExecutable execNode)
+					{
+						multiCommand.SetDefaultExecution(async (e)
+							=> await execNode.ExecuteAsync(e));
+					}
+				}
+				else
+				{
+					multiCommand.Children.Add(LoadCommand(c, multiCommand));
+				}
+			}
+			return multiCommand;
+		}
+
+		private Node LoadCommand(MethodInfo m, NodeContainer parent)
+		{
+			var commandAttrib = m.GetCustomAttribute<CommandAttribute>();
+			var command = new NodeExecutable(commandAttrib.AsMetadata(), parent, CreateDelegate(parent.Type, m));
+
+			if(m.ReturnType != typeof(Task))
+			{
+				throw new Exception("Methods with attribute 'Command' require to be Tasks.");
+			}
+			return command;
+		}
+		
+		private CommandDelegate CreateDelegate(Type type, MethodInfo methodInfo)
+		{
+			var context = Expression.Parameter(typeof(IContext));
+			var builder = new ParameterBuilder(context);
+			var constructors = type.GetConstructors();
+			var module = constructors.Length switch
+			{
+				0 => Expression.New(type),
+				1 => Expression.New(constructors[0], GetParameterValues(builder, constructors[0])),
+				_ => throw new NotSupportedException($"The module {type} has multiple constructors")
+			};
+			var parameterValues = GetParameterValues(builder, methodInfo);
+			var returnType = methodInfo.ReturnType;
+			Expression result = Expression.Call(module, methodInfo, parameterValues);
+
+			if (returnType == typeof(void))
+			{
+				var taskComplete = Expression.Property(null, TaskCompleteProperty);
+				var returnTarget = Expression.Label(typeof(Task));
+
+				result = Expression.Block(new[]
+				{
+					result,
+					Expression.Return(returnTarget, taskComplete),
+					Expression.Label(returnTarget, taskComplete)
+				});
+			}
+			else if (returnType != typeof(Task))
+			{
+				throw new InvalidOperationException($"Method {type.Name}.{methodInfo.Name} should return Task or void.");
+			}
+			
+			return Expression.Lambda<CommandDelegate>(result, context).Compile();
+		}
+
+		private Expression[] GetParameterValues(ParameterBuilder builder, MethodBase methodInfo)
+		{
+			var parameters = methodInfo.GetParameters();
+			var parameterValues = new Expression[parameters.Length];
+
+			for (var i = 0; i < parameters.Length; i++)
+			{
+				var paramType = parameters[i].ParameterType;
+				var provider = parameterProviders.FirstOrDefault(p => paramType.IsAssignableFrom(p.ParameterType));
+				Expression paramExpression;
+
+				if (provider != null)
+				{
+					paramExpression = provider.Provide(builder);
+				}
+				else if (paramType == typeof(IContext))
+				{
+					paramExpression = builder.Context;
+				}
+				else if (paramType == typeof(IMessage))
+				{
+					paramExpression = Expression.Property(builder.Context, nameof(IContext.Message));
+				}
+				else
+				{
+					paramExpression = builder.GetService(paramType);
+				}
+
+				parameterValues[i] = paramExpression;
+			}
+
+			return parameterValues;
+		}
+    }
+}

--- a/src/Miki.Framework.Commands/Extensions/MiddlewareExtensions.cs
+++ b/src/Miki.Framework.Commands/Extensions/MiddlewareExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Miki.Discord.Common;
 using Miki.Framework.Commands.Pipelines;
 using Miki.Framework.Hosting;
 
@@ -11,7 +12,10 @@ namespace Miki.Framework.Commands
         {
             return app.Use(next =>
             {
-                return context => stage.CheckAsync(context.Message, (IMutableContext) context, () => next(context));
+                return context => stage.CheckAsync(
+                    (IDiscordMessage) context.Message.InnerMessage,
+                    (IMutableContext) context, 
+                    () => next(context));
             });
         }
 

--- a/src/Miki.Framework.Commands/Extensions/MiddlewareExtensions.cs
+++ b/src/Miki.Framework.Commands/Extensions/MiddlewareExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using Miki.Framework.Commands.Pipelines;
+using Miki.Framework.Hosting;
+
+namespace Miki.Framework.Commands
+{
+    public static class MiddlewareExtensions
+    {
+        public static IBotApplicationBuilder UseStage(this IBotApplicationBuilder app, IPipelineStage stage)
+        {
+            return app.Use(next =>
+            {
+                return context => stage.CheckAsync(context.Message, (IMutableContext) context, () => next(context));
+            });
+        }
+
+        public static IBotApplicationBuilder UseStage<T>(this IBotApplicationBuilder app)
+            where T : IPipelineStage
+        {
+            return UseStage(app, app.ApplicationServices.GetOrCreateService<T>());
+        }
+
+        public static IBotApplicationBuilder UsePipeline(this IBotApplicationBuilder app, Action<CommandPipelineBuilder> configure)
+        {
+            var builder = new CommandPipelineBuilder(app.ApplicationServices);
+            configure(builder);
+
+            foreach (var stage in builder.Stages)
+            {
+                UseStage(app, stage);
+            }
+            
+            return app;
+        }
+    }
+}

--- a/src/Miki.Framework.Commands/Extensions/ServiceExtensions.cs
+++ b/src/Miki.Framework.Commands/Extensions/ServiceExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Miki.Framework.Commands
+{
+    public static class ServiceExtensions
+    {
+        public static IServiceCollection AddCommands(this IServiceCollection services, Assembly assembly)
+        {
+            return AddCommands(services, builder => builder.AddAssembly(assembly));
+        }
+        
+        public static IServiceCollection AddCommands(this IServiceCollection services, Action<CommandTreeBuilder> configure)
+        {
+            var builder = new CommandTreeBuilder(services);
+            configure(builder);
+            services.AddSingleton(provider => builder.Build(provider));
+            return services;
+        }
+    }
+}

--- a/src/Miki.Framework.Commands/Models/Nodes/Node.cs
+++ b/src/Miki.Framework.Commands/Models/Nodes/Node.cs
@@ -16,15 +16,15 @@
         public IReadOnlyCollection<Attribute> Attributes => Type.GetCustomAttributes<Attribute>(false)
 				.ToList();
 
-		private MemberInfo Type { get; }
+		public Type Type { get; }
 
-		protected Node(CommandMetadata metadata, MemberInfo type)
+		protected Node(CommandMetadata metadata, Type type)
 		{
 			Metadata = metadata;
 			Type = type;
 		}
 
-        protected Node(CommandMetadata metadata, NodeContainer parent, MemberInfo type)
+        protected Node(CommandMetadata metadata, NodeContainer parent, Type type)
             : this(metadata, type)
         {
             Parent = parent ?? throw new InvalidOperationException("Parent cannot be null when explicitly set up.");

--- a/src/Miki.Framework.Commands/Models/Nodes/NodeContainer.cs
+++ b/src/Miki.Framework.Commands/Models/Nodes/NodeContainer.cs
@@ -10,22 +10,13 @@
 	{
 		public List<Node> Children = new List<Node>();
 
-		/// <summary>
-		/// Instance object for reflection.
-		/// </summary>
-		public object Instance { get; }
-
 		public NodeContainer(CommandMetadata metadata, Type t)
 			: base(metadata, t)
 		{
 		}
-		public NodeContainer(CommandMetadata metadata, NodeContainer parent, IServiceProvider provider, Type t)
+		public NodeContainer(CommandMetadata metadata, NodeContainer parent, Type t)
 			: base(metadata, parent, t)
 		{
-			if(t != null)
-			{
-				Instance = ActivatorUtilities.CreateInstance(provider, t);
-			}
 		}
 
 		public virtual Node FindCommand(IArgumentPack pack)

--- a/src/Miki.Framework.Commands/Models/Nodes/NodeExecutable.cs
+++ b/src/Miki.Framework.Commands/Models/Nodes/NodeExecutable.cs
@@ -1,32 +1,26 @@
-﻿﻿namespace Miki.Framework.Commands.Nodes
+﻿﻿using System.Linq.Expressions;
+ using Miki.Framework.Models;
+
+ namespace Miki.Framework.Commands.Nodes
 {
     using System;
     using System.Linq;
     using System.Reflection;
     using System.Threading.Tasks;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member 'CommandDelegate'
     public delegate Task CommandDelegate(IContext c);
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member 'CommandDelegate'
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member 'NodeExecutable'
 	public class NodeExecutable : Node, IExecutable
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member 'NodeExecutable'
 	{
 		private readonly CommandDelegate runAsync;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member 'NodeExecutable.NodeExecutable(CommandMetadata, NodeContainer, MethodInfo)'
-		public NodeExecutable(CommandMetadata metadata, NodeContainer parent, MethodInfo method)
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member 'NodeExecutable.NodeExecutable(CommandMetadata, NodeContainer, MethodInfo)'
-			: base(metadata, parent, method)
+		public NodeExecutable(CommandMetadata metadata, NodeContainer parent, CommandDelegate commandDelegate)
+			: base(metadata, parent, parent.Type)
 		{
-			runAsync = (CommandDelegate)Delegate.CreateDelegate(
-				typeof(CommandDelegate), parent.Instance, method, true);
+			runAsync = commandDelegate;
 		}
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member 'NodeExecutable.ExecuteAsync(IContext)'
 		public async ValueTask ExecuteAsync(IContext e)
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member 'NodeExecutable.ExecuteAsync(IContext)'
 		{
 			if(runAsync == null)
 			{

--- a/src/Miki.Framework.Commands/Models/Nodes/NodeModule.cs
+++ b/src/Miki.Framework.Commands/Models/Nodes/NodeModule.cs
@@ -5,10 +5,10 @@
     public class NodeModule : NodeContainer
 	{
 		public NodeModule(string id, IServiceProvider provider, Type t)
-			: this(id, null, provider, t)
+			: this(id, (NodeContainer) null, t)
 		{ }
-		public NodeModule(string id, NodeContainer parent, IServiceProvider provider, Type t)
-			: base(new CommandMetadata { Identifiers = new[] { id } }, parent, provider, t)
+		public NodeModule(string id, NodeContainer parent, Type t)
+			: base(new CommandMetadata { Identifiers = new[] { id } }, parent, t)
 		{ }
 	}
 }

--- a/src/Miki.Framework.Commands/Models/Nodes/NodeNestedExecutable.cs
+++ b/src/Miki.Framework.Commands/Models/Nodes/NodeNestedExecutable.cs
@@ -23,23 +23,21 @@
 			CommandMetadata metadata,
 			IServiceProvider builder,
 			Type t)
-			: this(metadata, null, builder, t)
+			: this(metadata, (NodeContainer) null, t)
 		{
 		}
 
-		/// <summary>
-		/// Creates a new Nested, Executable Node.
-		/// </summary>
-		/// <param name="metadata">Command properties.</param>
-		/// <param name="parent"></param>
-		/// <param name="builder"></param>
-		/// <param name="t"></param>
-		public NodeNestedExecutable(
+        /// <summary>
+        /// Creates a new Nested, Executable Node.
+        /// </summary>
+        /// <param name="metadata">Command properties.</param>
+        /// <param name="parent"></param>
+        /// <param name="t"></param>
+        public NodeNestedExecutable(
 			CommandMetadata metadata,
 			NodeContainer parent,
-			IServiceProvider builder,
 			Type t)
-			: base(metadata, parent, builder, t)
+			: base(metadata, parent, t)
 		{
 		}
 

--- a/src/Miki.Framework.Commands/Stages/CorePipelineStage.cs
+++ b/src/Miki.Framework.Commands/Stages/CorePipelineStage.cs
@@ -34,7 +34,7 @@ namespace Miki.Framework
 	    [Obsolete("Use IContext.Message instead")]
 		public static IDiscordMessage GetMessage(this IContext context)
 		{
-			return context.Message;
+			return context.Message ?? context.GetContext<IDiscordMessage>(CorePipelineStage.MessageContextKey);
         }
 
         /// <summary>

--- a/src/Miki.Framework.Commands/Stages/CorePipelineStage.cs
+++ b/src/Miki.Framework.Commands/Stages/CorePipelineStage.cs
@@ -31,10 +31,9 @@ namespace Miki.Framework
 
     public static class CorePipelineStageExtensions
     {
-	    [Obsolete("Use IContext.Message instead")]
 		public static IDiscordMessage GetMessage(this IContext context)
 		{
-			return context.Message ?? context.GetContext<IDiscordMessage>(CorePipelineStage.MessageContextKey);
+			return context.GetContext<IDiscordMessage>(CorePipelineStage.MessageContextKey);
         }
 
         /// <summary>

--- a/src/Miki.Framework.Commands/Stages/CorePipelineStage.cs
+++ b/src/Miki.Framework.Commands/Stages/CorePipelineStage.cs
@@ -1,4 +1,6 @@
-﻿namespace Miki.Framework.Commands
+﻿using System;
+
+namespace Miki.Framework.Commands
 {
     using Miki.Discord.Common;
     using Miki.Framework.Commands.Pipelines;
@@ -29,9 +31,10 @@ namespace Miki.Framework
 
     public static class CorePipelineStageExtensions
     {
+	    [Obsolete("Use IContext.Message instead")]
 		public static IDiscordMessage GetMessage(this IContext context)
 		{
-			return context.GetContext<IDiscordMessage>(CorePipelineStage.MessageContextKey);
+			return context.Message;
         }
 
         /// <summary>

--- a/src/Miki.Framework.Discord/DiscordClientFactory.cs
+++ b/src/Miki.Framework.Discord/DiscordClientFactory.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading.Tasks;
+using Miki.Cache;
+using Miki.Discord;
+using Miki.Discord.Common;
+using Miki.Discord.Gateway;
+using Miki.Discord.Rest;
+using Miki.Framework.Hosting;
+
+namespace Miki.Framework.Discord
+{
+    public class DiscordClientFactory : IDiscordClientFactory
+    {
+        private readonly IExtendedCacheClient cacheClient;
+        private readonly DiscordToken token;
+
+        public DiscordClientFactory(IExtendedCacheClient cacheClient, DiscordToken token)
+        {
+            this.cacheClient = cacheClient;
+            this.token = token;
+        }
+
+        public Task<IDiscordClient> CreateClientAsync()
+        {
+            var gateway = new GatewayShard(new GatewayProperties
+            {
+                ShardCount = 1,
+                ShardId = 0,
+                Token = token.Token,
+                AllowNonDispatchEvents = true,
+                Intents = GatewayIntents.AllDefault | GatewayIntents.GuildMembers
+            });
+
+            var apiClient = new DiscordApiClient(token, cacheClient);
+            
+            var configuration = new DiscordClientConfigurations
+            {
+                Gateway = gateway,
+                ApiClient = apiClient,
+                CacheClient = cacheClient
+            };
+
+            return Task.FromResult<IDiscordClient>(new DiscordClient(configuration));
+        }
+    }
+}

--- a/src/Miki.Framework.Discord/Extensions/DiscordServiceExtensions.cs
+++ b/src/Miki.Framework.Discord/Extensions/DiscordServiceExtensions.cs
@@ -1,15 +1,36 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Miki.Discord.Common;
 using Miki.Framework.Discord;
+using Miki.Framework.Discord.Factories;
+using Miki.Framework.Discord.Services;
 
 // ReSharper disable once CheckNamespace
 namespace Miki.Framework
 {
     public static class DiscordServiceExtensions
     {
+        public static IServiceCollection AddDiscord(this IServiceCollection services, Type factoryType, params object[] factoryArguments)
+        {
+            services.AddHostedService(provider =>
+            {
+                var factory = (IDiscordClientFactory) ActivatorUtilities.CreateInstance(provider, factoryType, factoryArguments);
+                
+                return ActivatorUtilities.CreateInstance<DiscordHostedService>(provider, factory);
+            });
+            
+            return services;
+        }
+        
+        public static IServiceCollection AddDiscord<TFactory>(this IServiceCollection services, params object[] factoryArguments)
+            where TFactory : IDiscordClientFactory
+        {
+            return AddDiscord(services, typeof(TFactory), factoryArguments);
+        }
+        
         public static IServiceCollection AddDiscord(this IServiceCollection services, DiscordToken token)
         {
-            services.AddDiscord<DiscordClientFactory>(token);
+            AddDiscord<DefaultDiscordClientFactory>(services, token);
             return services;
         }
     }

--- a/src/Miki.Framework.Discord/Extensions/DiscordServiceExtensions.cs
+++ b/src/Miki.Framework.Discord/Extensions/DiscordServiceExtensions.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Miki.Discord.Common;
-using Miki.Framework.Discord;
 using Miki.Framework.Discord.Factories;
+using Miki.Framework.Discord.Providers;
 using Miki.Framework.Discord.Services;
+using Miki.Framework.Hosting;
 
 // ReSharper disable once CheckNamespace
 namespace Miki.Framework
@@ -12,6 +13,8 @@ namespace Miki.Framework
     {
         public static IServiceCollection AddDiscord(this IServiceCollection services, Type factoryType, params object[] factoryArguments)
         {
+            services.AddSingleton<IParameterProvider, DiscordClientParameterProvider>();
+            
             services.AddHostedService(provider =>
             {
                 var factory = (IDiscordClientFactory) ActivatorUtilities.CreateInstance(provider, factoryType, factoryArguments);

--- a/src/Miki.Framework.Discord/Extensions/DiscordServiceExtensions.cs
+++ b/src/Miki.Framework.Discord/Extensions/DiscordServiceExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Miki.Discord.Common;
+using Miki.Framework.Discord;
+
+// ReSharper disable once CheckNamespace
+namespace Miki.Framework
+{
+    public static class DiscordServiceExtensions
+    {
+        public static IServiceCollection AddDiscord(this IServiceCollection services, DiscordToken token)
+        {
+            services.AddDiscord<DiscordClientFactory>(token);
+            return services;
+        }
+    }
+}

--- a/src/Miki.Framework.Discord/Factories/DefaultDiscordClientFactory.cs
+++ b/src/Miki.Framework.Discord/Factories/DefaultDiscordClientFactory.cs
@@ -4,16 +4,15 @@ using Miki.Discord;
 using Miki.Discord.Common;
 using Miki.Discord.Gateway;
 using Miki.Discord.Rest;
-using Miki.Framework.Hosting;
 
-namespace Miki.Framework.Discord
+namespace Miki.Framework.Discord.Factories
 {
-    public class DiscordClientFactory : IDiscordClientFactory
+    public class DefaultDiscordClientFactory : IDiscordClientFactory
     {
         private readonly IExtendedCacheClient cacheClient;
         private readonly DiscordToken token;
 
-        public DiscordClientFactory(IExtendedCacheClient cacheClient, DiscordToken token)
+        public DefaultDiscordClientFactory(IExtendedCacheClient cacheClient, DiscordToken token)
         {
             this.cacheClient = cacheClient;
             this.token = token;

--- a/src/Miki.Framework.Discord/Factories/IDiscordClientFactory.cs
+++ b/src/Miki.Framework.Discord/Factories/IDiscordClientFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Miki.Discord.Common;
 
-namespace Miki.Framework.Hosting
+namespace Miki.Framework.Discord.Factories
 {
     public interface IDiscordClientFactory
     {

--- a/src/Miki.Framework.Discord/Miki.Framework.Discord.csproj
+++ b/src/Miki.Framework.Discord/Miki.Framework.Discord.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Configurations>Debug;Release;Debug Production;Prod</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <Authors>Velddev</Authors>
+    <Company />
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Version>2.3.1</Version>
+    <PackageProjectUrl>https://github.com/mikibot/miki.framework</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mikibot/miki.framework</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Copyright>Velddev</Copyright>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Miki.Discord" Version="3.3.0" />
+    <PackageReference Include="Miki.Discord.Gateway" Version="3.3.11" />
+    <PackageReference Include="Miki.Discord.Rest" Version="3.3.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Miki.Framework\Miki.Framework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Miki.Framework.Discord/Providers/DiscordClientParameterProvider.cs
+++ b/src/Miki.Framework.Discord/Providers/DiscordClientParameterProvider.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Linq.Expressions;
+using Miki.Discord.Common;
+using Miki.Framework.Hosting;
+
+namespace Miki.Framework.Discord.Providers
+{
+    public class DiscordClientParameterProvider : IParameterProvider
+    {
+        public Type ParameterType => typeof(IDiscordClient);
+        
+        public Expression Provide(ParameterBuilder context)
+        {
+            return context.GetContext(typeof(IDiscordClient), "DiscordClient");
+        }
+    }
+}

--- a/src/Miki.Framework.Discord/Services/DiscordHostedService.cs
+++ b/src/Miki.Framework.Discord/Services/DiscordHostedService.cs
@@ -32,6 +32,8 @@ namespace Miki.Framework.Discord.Services
         {
             using var scope = serviceProvider.CreateScope();
             using var context = new ContextObject(scope.ServiceProvider, new DiscordMessage(message));
+
+            context.SetContext("DiscordClient", discordClient);
             
             try
             {

--- a/src/Miki.Framework.Discord/Services/DiscordHostedService.cs
+++ b/src/Miki.Framework.Discord/Services/DiscordHostedService.cs
@@ -4,9 +4,12 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Miki.Discord.Common;
+using Miki.Framework.Discord.Factories;
+using Miki.Framework.Hosting;
+using Miki.Framework.Models;
 using Miki.Logging;
 
-namespace Miki.Framework.Hosting
+namespace Miki.Framework.Discord.Services
 {
     public class DiscordHostedService : IHostedService, IDisposable
     {
@@ -28,7 +31,7 @@ namespace Miki.Framework.Hosting
         private async Task HandleMessageAsync(IDiscordMessage message)
         {
             using var scope = serviceProvider.CreateScope();
-            using var context = new ContextObject(scope.ServiceProvider, message);
+            using var context = new ContextObject(scope.ServiceProvider, new DiscordMessage(message));
             
             try
             {

--- a/src/Miki.Framework.sln
+++ b/src/Miki.Framework.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Miki.Framework.Commands.Fil
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{4BE94594-5456-49B4-AA9D-4BBDCD77BCE3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Miki.Framework.Discord", "Miki.Framework.Discord\Miki.Framework.Discord.csproj", "{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug Production|Any CPU = Debug Production|Any CPU
@@ -123,6 +125,14 @@ Global
 		{C8F412EB-645B-42EA-B21E-5A04D813D930}.Prod|Any CPU.Build.0 = Debug|Any CPU
 		{C8F412EB-645B-42EA-B21E-5A04D813D930}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8F412EB-645B-42EA-B21E-5A04D813D930}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Debug Production|Any CPU.ActiveCfg = Debug Production|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Debug Production|Any CPU.Build.0 = Debug Production|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Prod|Any CPU.ActiveCfg = Prod|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Prod|Any CPU.Build.0 = Prod|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B213EE14-D5E9-41CD-B53A-8F3ECDEE515F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Miki.Framework/ContextObject.cs
+++ b/src/Miki.Framework/ContextObject.cs
@@ -1,4 +1,6 @@
-﻿namespace Miki.Framework
+﻿using Miki.Discord.Common;
+
+namespace Miki.Framework
 {
     using Microsoft.Extensions.DependencyInjection;
     using System;
@@ -9,6 +11,11 @@
 	/// </summary>
     public interface IContext
 	{
+		/// <summary>
+		/// The message received from discord.
+		/// </summary>
+		IDiscordMessage Message { get; }
+		
 		/// <summary>
 		/// The command executed in this current session.
 		/// </summary>
@@ -45,6 +52,9 @@
         public IServiceProvider Services
 			=> scope.ServiceProvider;
 
+		/// <inheritdoc />
+		public IDiscordMessage Message { get; }
+
 		/// <summary>
 		/// Current set Executable.
 		/// </summary>
@@ -53,8 +63,9 @@
 		/// <summary>
 		/// Creates a scoped context object
 		/// </summary>
-        public ContextObject(IServiceProvider p)
+        public ContextObject(IServiceProvider p, IDiscordMessage message)
 		{
+			Message = message;
 			contextObjects = new Dictionary<string, object>();
 			scope = p.CreateScope();
 		}

--- a/src/Miki.Framework/ContextObject.cs
+++ b/src/Miki.Framework/ContextObject.cs
@@ -1,4 +1,5 @@
 ﻿using Miki.Discord.Common;
+using Miki.Framework.Models;
 
 namespace Miki.Framework
 {
@@ -14,7 +15,7 @@ namespace Miki.Framework
 		/// <summary>
 		/// The message received from discord.
 		/// </summary>
-		IDiscordMessage Message { get; }
+		IMessage Message { get; }
 		
 		/// <summary>
 		/// The command executed in this current session.
@@ -53,7 +54,7 @@ namespace Miki.Framework
 			=> scope.ServiceProvider;
 
 		/// <inheritdoc />
-		public IDiscordMessage Message { get; }
+		public IMessage Message { get; }
 
 		/// <summary>
 		/// Current set Executable.
@@ -63,7 +64,7 @@ namespace Miki.Framework
 		/// <summary>
 		/// Creates a scoped context object
 		/// </summary>
-        public ContextObject(IServiceProvider p, IDiscordMessage message)
+        public ContextObject(IServiceProvider p, IMessage message)
 		{
 			Message = message;
 			contextObjects = new Dictionary<string, object>();

--- a/src/Miki.Framework/Extension/HostExtensions.cs
+++ b/src/Miki.Framework/Extension/HostExtensions.cs
@@ -1,0 +1,22 @@
+﻿﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Miki.Framework.Hosting;
+
+namespace Miki.Framework
+{
+    public static class HostExtensions
+    {
+        public static IHostBuilder ConfigureBot(
+            this IHostBuilder hostBuilder,
+            Action<IBotApplicationBuilder> configure = null)
+        {
+            hostBuilder.ConfigureServices((ctx, services) =>
+            {
+                services.AddSingleton<IBotApplicationBuilderFactory>(provider => new BotApplicationBuilderFactory(provider, hostBuilder, configure));
+            });
+
+            return hostBuilder;
+        }
+    }
+}

--- a/src/Miki.Framework/Extension/MiddlewareExtensions.cs
+++ b/src/Miki.Framework/Extension/MiddlewareExtensions.cs
@@ -1,0 +1,152 @@
+﻿﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Miki.Framework.Hosting;
+
+namespace Miki.Framework
+{
+    using Predicate = Func<IContext, bool>;
+    using PredicateAsync = Func<IContext, ValueTask<bool>>;
+    
+    public static class MiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds a middleware delegate defined in-line to the application's request pipeline.
+        /// </summary>
+        /// <param name="app">The <see cref="IBotApplicationBuilder"/> instance.</param>
+        /// <param name="middleware">A function that handles the request or calls the given next function.</param>
+        /// <returns>The <see cref="IBotApplicationBuilder"/> instance.</returns>
+        public static IBotApplicationBuilder Use(this IBotApplicationBuilder app, Func<IContext, Func<ValueTask>, ValueTask> middleware)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+            
+            if (middleware == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+            
+            return app.Use(next =>
+            {
+                return context =>
+                {
+                    return middleware(context, () => next(context));
+                };
+            });
+        }
+        
+        /// <summary>
+        /// Adds a terminal middleware delegate to the application's request pipeline.
+        /// </summary>
+        /// <param name="app">The <see cref="IBotApplicationBuilder"/> instance.</param>
+        /// <param name="handler">A delegate that handles the request.</param>
+        public static void Run(this IBotApplicationBuilder app, MessageDelegate handler)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            app.Use(_ => handler);
+        }
+        
+        /// <summary>
+        /// Conditionally creates a branch in the request pipeline that is rejoined to the main pipeline.
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="predicate">Invoked with the request environment to determine if the branch should be taken</param>
+        /// <param name="configuration">Configures a branch to take</param>
+        /// <returns></returns>
+        public static IBotApplicationBuilder UseWhen(this IBotApplicationBuilder app, Predicate predicate, Action<IBotApplicationBuilder> configuration)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+            
+            // Create and configure the branch builder right away; otherwise,
+            // we would end up running our branch after all the components
+            // that were subsequently added to the main builder.
+            var branchBuilder = app.New();
+            configuration(branchBuilder);
+
+            return app.Use(main =>
+            {
+                // This is called only when the main application builder 
+                // is built, not per request.
+                branchBuilder.Run(main);
+                var branch = branchBuilder.Build();
+
+                return context => predicate(context) ? branch(context) : main(context);
+            });
+        }
+        
+        /// <summary>
+        /// Conditionally creates a branch in the request pipeline that is rejoined to the main pipeline.
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="predicate">Invoked with the request environment to determine if the branch should be taken</param>
+        /// <param name="configuration">Configures a branch to take</param>
+        /// <returns></returns>
+        public static IBotApplicationBuilder UseWhen(this IBotApplicationBuilder app, PredicateAsync predicate, Action<IBotApplicationBuilder> configuration)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+            
+            // Create and configure the branch builder right away; otherwise,
+            // we would end up running our branch after all the components
+            // that were subsequently added to the main builder.
+            var branchBuilder = app.New();
+            configuration(branchBuilder);
+
+            return app.Use(main =>
+            {
+                // This is called only when the main application builder 
+                // is built, not per request.
+                branchBuilder.Run(main);
+                var branch = branchBuilder.Build();
+
+                return async context =>
+                {
+                    if (await predicate(context))
+                    {
+                        await branch(context);
+                    }
+                    else
+                    {
+                        await main(context);
+                    }
+                };
+            });
+        }
+    }
+}

--- a/src/Miki.Framework/Extension/ServiceExtensions.cs
+++ b/src/Miki.Framework/Extension/ServiceExtensions.cs
@@ -20,23 +20,5 @@ namespace Miki.Framework
             services.AddSingleton<IExtendedCacheClient, T>();
             return services;
         }
-        
-        public static IServiceCollection AddDiscord(this IServiceCollection services, Type factoryType, params object[] factoryArguments)
-        {
-            services.AddHostedService(provider =>
-            {
-                var factory = (IDiscordClientFactory) ActivatorUtilities.CreateInstance(provider, factoryType, factoryArguments);
-                
-                return ActivatorUtilities.CreateInstance<DiscordHostedService>(provider, factory);
-            });
-            
-            return services;
-        }
-        
-        public static IServiceCollection AddDiscord<TFactory>(this IServiceCollection services, params object[] factoryArguments)
-            where TFactory : IDiscordClientFactory
-        {
-            return AddDiscord(services, typeof(TFactory), factoryArguments);
-        }
     }
 }

--- a/src/Miki.Framework/Extension/ServiceExtensions.cs
+++ b/src/Miki.Framework/Extension/ServiceExtensions.cs
@@ -1,0 +1,42 @@
+﻿﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+ using Miki.Cache;
+ using Miki.Discord.Common;
+using Miki.Framework.Hosting;
+
+namespace Miki.Framework
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static T GetOrCreateService<T>(this IServiceProvider provider)
+        {
+            return provider.GetService<T>() ?? ActivatorUtilities.CreateInstance<T>(provider);
+        }
+        
+        public static IServiceCollection AddCacheClient<T>(this IServiceCollection services)
+            where T : class, IExtendedCacheClient
+        {
+            services.AddSingleton<ICacheClient>(provider => provider.GetService<IExtendedCacheClient>());
+            services.AddSingleton<IExtendedCacheClient, T>();
+            return services;
+        }
+        
+        public static IServiceCollection AddDiscord(this IServiceCollection services, Type factoryType, params object[] factoryArguments)
+        {
+            services.AddHostedService(provider =>
+            {
+                var factory = (IDiscordClientFactory) ActivatorUtilities.CreateInstance(provider, factoryType, factoryArguments);
+                
+                return ActivatorUtilities.CreateInstance<DiscordHostedService>(provider, factory);
+            });
+            
+            return services;
+        }
+        
+        public static IServiceCollection AddDiscord<TFactory>(this IServiceCollection services, params object[] factoryArguments)
+            where TFactory : IDiscordClientFactory
+        {
+            return AddDiscord(services, typeof(TFactory), factoryArguments);
+        }
+    }
+}

--- a/src/Miki.Framework/Hosting/BotApplicationBuilder.cs
+++ b/src/Miki.Framework/Hosting/BotApplicationBuilder.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Miki.Framework.Utils;
+
+namespace Miki.Framework.Hosting
+{
+    public class BotApplicationBuilder : IBotApplicationBuilder
+    {
+        private const string ApplicationServicesKey = "Miki.ApplicationServices";
+        
+        private readonly IList<Func<MessageDelegate, MessageDelegate>> components = new List<Func<MessageDelegate, MessageDelegate>>();
+
+        public BotApplicationBuilder()
+        {
+            Properties = new Dictionary<string, object>();
+        }
+        
+        public BotApplicationBuilder(IBotApplicationBuilder builder)
+        {
+            Properties = new CopyOnWriteDictionary<string, object>(builder.Properties, StringComparer.Ordinal);
+        }
+
+        public IServiceProvider ApplicationServices
+        {
+            get => GetProperty<IServiceProvider>(ApplicationServicesKey);
+            set => SetProperty(ApplicationServicesKey, value);
+        }
+
+        public IDictionary<string, object> Properties { get; }
+
+        public T GetProperty<T>(string key)
+        {
+            return Properties.TryGetValue(key, out var value) ? (T) value : default;
+        }
+
+        public void SetProperty<T>(string key, T value)
+        {
+            Properties[key] = value;
+        }
+
+        public IBotApplicationBuilder Use(Func<MessageDelegate, MessageDelegate> middleware)
+        {
+            components.Add(middleware);
+            return this;
+        }
+        
+        private static ValueTask InvokeAsync(IContext context)
+        {
+            return context.Executable?.ExecuteAsync(context) ?? default;
+        }
+
+        public MessageDelegate Build()
+        {
+            return components.Reverse().Aggregate((MessageDelegate) InvokeAsync, (current, component) => component(current));
+        }
+
+        public IBotApplicationBuilder New()
+        {
+            return new BotApplicationBuilder(this);
+        }
+    }
+}

--- a/src/Miki.Framework/Hosting/BotApplicationBuilderFactory.cs
+++ b/src/Miki.Framework/Hosting/BotApplicationBuilderFactory.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Miki.Framework.Hosting
+{
+    public class BotApplicationBuilderFactory : IBotApplicationBuilderFactory
+    {
+        private readonly Action<IBotApplicationBuilder> configure;
+        private readonly IServiceProvider serviceProvider;
+        private readonly IHostBuilder hostBuilder;
+
+        public BotApplicationBuilderFactory(
+            IServiceProvider serviceProvider,
+            IHostBuilder hostBuilder = null,
+            Action<IBotApplicationBuilder> configure = null)
+        {
+            this.configure = configure;
+            this.serviceProvider = serviceProvider;
+            this.hostBuilder = hostBuilder;
+        }
+
+        public IBotApplicationBuilder CreateBuilder()
+        {
+            var builder = new BotApplicationBuilder
+            {
+                ApplicationServices = serviceProvider
+            };
+
+            if (configure != null)
+            {
+                configure.Invoke(builder);
+            }
+            else if (hostBuilder != null
+                     && hostBuilder.Properties.TryGetValue("UseStartup.StartupType", out var value)
+                     && value is Type startupType)
+            {
+                InitializeStartup(serviceProvider, startupType, builder);
+            }
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Configure the pipeline through the ASP.NET Core startup class. 
+        /// </summary>
+        private static bool InitializeStartup(IServiceProvider provider, Type startupType, IBotApplicationBuilder builder)
+        {
+            var startupInterfaceType = Type.GetType("Microsoft.AspNetCore.Hosting.IStartup, Microsoft.AspNetCore.Hosting.Abstractions");
+            object startup;
+
+            if (startupInterfaceType != null)
+            {
+                startup = provider.GetService(startupInterfaceType);
+
+                if (startup != null)
+                {
+                    startupType = startup.GetType();
+                }
+            }
+            else
+            {
+                startup = null;
+            }
+
+            if (startup == null)
+            {
+                if (startupType != null)
+                {
+                    startup = ActivatorUtilities.CreateInstance(provider, startupType);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            var configureMethod = startupType.GetMethod("ConfigureBot");
+
+            if (configureMethod == null)
+            {
+                return false;
+            }
+            
+            var parameterInfos = configureMethod.GetParameters();
+            var parameters = new object[parameterInfos.Length];
+
+            for (var i = 0; i < parameterInfos.Length; i++)
+            {
+                var parameterType = parameterInfos[i].ParameterType;
+
+                if (parameterType == typeof(IBotApplicationBuilder))
+                {
+                    parameters[i] = builder;
+                }
+                else
+                {
+                    parameters[i] = provider.GetRequiredService(parameterType);
+                }
+            }
+
+            configureMethod.Invoke(startup, parameters);
+
+            return true;
+        }
+    }
+}

--- a/src/Miki.Framework/Hosting/DiscordHostedService.cs
+++ b/src/Miki.Framework/Hosting/DiscordHostedService.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Miki.Discord.Common;
+using Miki.Logging;
+
+namespace Miki.Framework.Hosting
+{
+    public class DiscordHostedService : IHostedService, IDisposable
+    {
+        private readonly IServiceProvider serviceProvider;
+        private readonly MessageDelegate invoke;
+        private readonly IDiscordClientFactory discordClientFactory;
+        private IDiscordClient discordClient;
+
+        public DiscordHostedService(
+            IBotApplicationBuilderFactory factory,
+            IServiceProvider serviceProvider,
+            IDiscordClientFactory discordClientFactory)
+        {
+            this.serviceProvider = serviceProvider;
+            this.discordClientFactory = discordClientFactory;
+            invoke = factory.CreateBuilder().Build();
+        }
+
+        private async Task HandleMessageAsync(IDiscordMessage message)
+        {
+            using var scope = serviceProvider.CreateScope();
+            using var context = new ContextObject(scope.ServiceProvider, message);
+            
+            try
+            {
+                await invoke(context);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e);
+            }
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (discordClient == null)
+            {
+                discordClient = await discordClientFactory.CreateClientAsync();
+                discordClient.MessageCreate += HandleMessageAsync;
+            }
+
+            await discordClient.Gateway.StartAsync();
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return discordClient?.Gateway.StopAsync() ?? Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            if (discordClient != null)
+            {
+                discordClient.MessageCreate -= HandleMessageAsync;
+            }
+        }
+    }
+}

--- a/src/Miki.Framework/Hosting/IBotApplicationBuilder.cs
+++ b/src/Miki.Framework/Hosting/IBotApplicationBuilder.cs
@@ -1,0 +1,55 @@
+﻿﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Miki.Framework.Hosting
+{
+    public delegate ValueTask MessageDelegate(IContext context);
+
+    public interface IBotApplicationBuilder
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="IServiceProvider"/> that provides access to the application's service container.
+        /// </summary>
+        IServiceProvider ApplicationServices { get; set; }
+
+        /// <summary>
+        /// Gets a key/value collection that can be used to share data between middleware.
+        /// </summary>
+        IDictionary<string, object> Properties { get; }
+
+        /// <summary>
+        /// Get the property by its key.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="key">The key of the property.</param>
+        /// <returns>The value of the property.</returns>
+        T GetProperty<T>(string key);
+
+        /// <summary>
+        /// Set the property by its key.
+        /// </summary>
+        /// <typeparam name="T">The type of the property.</typeparam>
+        /// <param name="key">The key of the property.</param>
+        /// <param name="value">The new value.</param>
+        void SetProperty<T>(string key, T value);
+
+        /// <summary>
+        /// Adds a middleware delegate to the application's request pipeline.
+        /// </summary>
+        /// <param name="middleware">The delegate middleware.</param>
+        /// <returns>The current application builder.</returns>
+        IBotApplicationBuilder Use(Func<MessageDelegate, MessageDelegate> middleware);
+
+        /// <summary>
+        /// Builds the delegate used by this application to process Discord messages.
+        /// </summary>
+        /// <returns></returns>
+        MessageDelegate Build();
+
+        /// <summary>
+        /// Create a sub-builder.
+        /// </summary>
+        IBotApplicationBuilder New();
+    }
+}

--- a/src/Miki.Framework/Hosting/IBotApplicationBuilderFactory.cs
+++ b/src/Miki.Framework/Hosting/IBotApplicationBuilderFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Miki.Framework.Hosting
+{
+    public interface IBotApplicationBuilderFactory
+    {
+        IBotApplicationBuilder CreateBuilder();
+    }
+}

--- a/src/Miki.Framework/Hosting/IDiscordClientFactory.cs
+++ b/src/Miki.Framework/Hosting/IDiscordClientFactory.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading.Tasks;
+using Miki.Discord.Common;
+
+namespace Miki.Framework.Hosting
+{
+    public interface IDiscordClientFactory
+    {
+        Task<IDiscordClient> CreateClientAsync();
+    }
+}

--- a/src/Miki.Framework/Hosting/IParameterProvider.cs
+++ b/src/Miki.Framework/Hosting/IParameterProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Miki.Framework.Hosting
+{
+    public interface IParameterProvider
+    {
+        Type ParameterType { get; }
+
+        Expression Provide(ParameterBuilder context);
+    }
+}

--- a/src/Miki.Framework/Hosting/ParameterBuilder.cs
+++ b/src/Miki.Framework/Hosting/ParameterBuilder.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Miki.Framework.Hosting
+{
+    public class ParameterBuilder
+    {
+        private static readonly MethodInfo GetServiceMethod = typeof(ContextExtensions)
+            .GetMethods()
+            .First(m => m.Name == nameof(ContextExtensions.GetService) && m.IsGenericMethod);
+		
+        private static readonly MethodInfo GetContextMethod = typeof(ContextExtensions)
+            .GetMethods()
+            .First(m => m.Name == nameof(ContextExtensions.GetContext) && m.IsGenericMethod);
+
+        public ParameterBuilder(Expression context)
+        {
+            Context = context;
+        }
+
+        public Expression Context { get; }
+		
+        public Expression GetService(Type type)
+        {
+            return Expression.Call(GetServiceMethod.MakeGenericMethod(type), Context);
+        }
+
+        public Expression GetContext(Type type, string name)
+        {
+            return Expression.Call(GetContextMethod.MakeGenericMethod(type), Context, Expression.Constant(name));
+        }
+    }
+}

--- a/src/Miki.Framework/Miki.Framework.csproj
+++ b/src/Miki.Framework/Miki.Framework.csproj
@@ -45,6 +45,7 @@
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="1.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.13" />
     <PackageReference Include="Miki.Cache" Version="1.4.0" />
     <PackageReference Include="Miki.Discord" Version="3.2.1" />

--- a/src/Miki.Framework/Models/DiscordMessage.cs
+++ b/src/Miki.Framework/Models/DiscordMessage.cs
@@ -1,0 +1,18 @@
+﻿using Miki.Discord.Common;
+
+namespace Miki.Framework.Models
+{
+    public class DiscordMessage : IMessage
+    {
+        private readonly IDiscordMessage message;
+
+        public DiscordMessage(IDiscordMessage message)
+        {
+            this.message = message;
+        }
+
+        public object InnerMessage => message;
+
+        public string Content => message.Content;
+    }
+}

--- a/src/Miki.Framework/Models/IChannel.cs
+++ b/src/Miki.Framework/Models/IChannel.cs
@@ -1,9 +1,0 @@
-﻿namespace Miki.Framework.Models
-{
-    using System.Threading.Tasks;
-
-    public interface IChannel
-    {
-        Task<IMessage> CreateMessageAsync(string content);
-    }
-}

--- a/src/Miki.Framework/Models/IMessage.cs
+++ b/src/Miki.Framework/Models/IMessage.cs
@@ -1,13 +1,9 @@
 ﻿namespace Miki.Framework.Models
 {
-    using System.Threading.Tasks;
-
     public interface IMessage
 	{
-		Task DeleteAsync();
-
-		Task<IChannel> GetChannelAsync();
-
-		Task<IMessage> ModifyAsync(string content);
+		object InnerMessage { get; }
+		
+		string Content { get; }
 	}
 }

--- a/src/Miki.Framework/TestContextObject.cs
+++ b/src/Miki.Framework/TestContextObject.cs
@@ -1,4 +1,6 @@
-﻿namespace Miki.Framework
+﻿using Miki.Discord.Common;
+
+namespace Miki.Framework
 {
     using System;
     using System.Collections.Generic;
@@ -10,6 +12,9 @@
     {
         private readonly Dictionary<string, object> contextObjects = new Dictionary<string, object>();
         private readonly Dictionary<Type, object> serviceObjects = new Dictionary<Type, object>();
+
+        /// <inheritdoc />
+        public IDiscordMessage Message { get; set; }
 
         /// <inheritdoc />
         public IExecutable Executable { get; set; }

--- a/src/Miki.Framework/TestContextObject.cs
+++ b/src/Miki.Framework/TestContextObject.cs
@@ -1,4 +1,5 @@
 ﻿using Miki.Discord.Common;
+using Miki.Framework.Models;
 
 namespace Miki.Framework
 {
@@ -14,7 +15,7 @@ namespace Miki.Framework
         private readonly Dictionary<Type, object> serviceObjects = new Dictionary<Type, object>();
 
         /// <inheritdoc />
-        public IDiscordMessage Message { get; set; }
+        public IMessage Message { get; set; }
 
         /// <inheritdoc />
         public IExecutable Executable { get; set; }

--- a/src/Miki.Framework/Utils/CopyOnWriteDictionary.cs
+++ b/src/Miki.Framework/Utils/CopyOnWriteDictionary.cs
@@ -1,0 +1,155 @@
+﻿﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Miki.Framework.Utils
+{
+    internal class CopyOnWriteDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly IDictionary<TKey, TValue> sourceDictionary;
+        private readonly IEqualityComparer<TKey> comparer;
+        private IDictionary<TKey, TValue> innerDictionary;
+
+        public CopyOnWriteDictionary(
+            IDictionary<TKey, TValue> sourceDictionary,
+            IEqualityComparer<TKey> comparer)
+        {
+            if (sourceDictionary == null)
+            {
+                throw new ArgumentNullException(nameof(sourceDictionary));
+            }
+
+            if (comparer == null)
+            {
+                throw new ArgumentNullException(nameof(comparer));
+            }
+
+            this.sourceDictionary = sourceDictionary;
+            this.comparer = comparer;
+        }
+
+        private IDictionary<TKey, TValue> ReadDictionary
+        {
+            get
+            {
+                return innerDictionary ?? sourceDictionary;
+            }
+        }
+
+        private IDictionary<TKey, TValue> WriteDictionary
+        {
+            get
+            {
+                if (innerDictionary == null)
+                {
+                    innerDictionary = new Dictionary<TKey, TValue>(sourceDictionary,
+                                                                    comparer);
+                }
+
+                return innerDictionary;
+            }
+        }
+
+        public virtual ICollection<TKey> Keys
+        {
+            get
+            {
+                return ReadDictionary.Keys;
+            }
+        }
+
+        public virtual ICollection<TValue> Values
+        {
+            get
+            {
+                return ReadDictionary.Values;
+            }
+        }
+
+        public virtual int Count
+        {
+            get
+            {
+                return ReadDictionary.Count;
+            }
+        }
+
+        public virtual bool IsReadOnly
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public virtual TValue this[TKey key]
+        {
+            get
+            {
+                return ReadDictionary[key];
+            }
+            set
+            {
+                WriteDictionary[key] = value;
+            }
+        }
+
+        public virtual bool ContainsKey(TKey key)
+        {
+            return ReadDictionary.ContainsKey(key);
+        }
+
+        public virtual void Add(TKey key, TValue value)
+        {
+            WriteDictionary.Add(key, value);
+        }
+
+        public virtual bool Remove(TKey key)
+        {
+            return WriteDictionary.Remove(key);
+        }
+
+        public virtual bool TryGetValue(TKey key, out TValue value)
+        {
+            return ReadDictionary.TryGetValue(key, out value);
+        }
+
+        public virtual void Add(KeyValuePair<TKey, TValue> item)
+        {
+            WriteDictionary.Add(item);
+        }
+
+        public virtual void Clear()
+        {
+            WriteDictionary.Clear();
+        }
+
+        public virtual bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ReadDictionary.Contains(item);
+        }
+
+        public virtual void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ReadDictionary.CopyTo(array, arrayIndex);
+        }
+
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return WriteDictionary.Remove(item);
+        }
+
+        public virtual IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+        {
+            return ReadDictionary.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds [Microsoft.Extensions.Hosting](https://www.nuget.org/packages/Microsoft.Extensions.Hosting/) support to Miki.Framework. This makes it way easier to set-up a new bot in a console application or even a ASP.NET Core application.

## Middlewares
This PR introduces `IBotApplicationBuilder` which is equal to [IApplicationBuilder](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.iapplicationbuilder) in ASP.Net Core.

You can define middlewares in `ConfigureBot`:

```cs
HostBuilder.ConfigureBot(app =>
{
    app.Use(async (context, func) =>
    {
        var channel = await context.Message.GetChannelAsync();

        await channel.SendMessageAsync("Hello world!")
    });
})
```

## Command pipeline
To use a command stage in the new middleware, you can use `app.UseStage<ClassName>()`.
To use the `CommandPipelineBuilder` extensions, you can use `app.UsePipeline`:

```cs
app.UsePipeline(builder =>
{
    builder.UsePrefixes();
    builder.UseArgumentPack();
    builder.UseCommandHandler();
});
```

## Example bot
```cs
public static Task Main(string[] args)
{
    return new HostBuilder()
        .ConfigureServices(services =>
        {
            services.AddDiscord("TOKEN");
            services.AddCacheClient<InMemoryCacheClient>();
            services.AddSingleton<ISerializer, ProtobufSerializer>();
        })
        .ConfigureBot(app =>
        {
            app.UseStage<FetchDataStage>();
            app.Use(async (context, next) =>
            {
                var message = context.Message;

                if (message.Content == "ping")
                {
                    await context.GetChannel().SendMessageAsync("Pong");
                }

                await next();
            });
        })
        .RunConsoleAsync();
}
```